### PR TITLE
[fix] Updates main script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm install react-virtual-list --save
 The `./dist/VirtualList.js` module exports a single React component.
 
 ```
-var VirtualList = require('./node_modules/react-virtual-list/dist/VirtualList.js');
+var VirtualList = require('react-virtual-list');
 ```
 
 #### JSX

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-virtual-list",
   "version": "1.4.1",
   "description": "Super simple virtualized list React component",
-  "main": "dist/virtual-list.js",
+  "main": "dist/VirtualList.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
`require('react-virtual-list')` currently doesn't work because package.json uses `dist/virtual-list.js` instead of `dist/VirtualList.js` as output by Gulp. Since changing the actual output would mean changing the Gulpfile (and would break code already using on `require('react-virtual-list/dist/VirtualList')` roughly as documented), this is probably the path of least resistance to fix it. This PR also updates the documentation to reflect the change.