### PR TITLE
Added initialItems prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ var VirtualList = require('react-virtual-list');
 * `tagName` the tagName for the root element that surrounds the items rendered by renderItem.  Defaults to `div`.  Use this if you want to render a list with `ul` and `li`, or any other elements.
 * `scrollDelay` the delay in milliseconds after scroll to recalculate.  Defaults to `0`.  Can be used to throttle recalculation.
 * `itemBuffer` the number of items that should be rendered before and after the visible viewport.  Defaults to `0`.
+* `initialItems` an array of list items that should be rendered initially and on the server.  Defaults to `[]`.
  
 Any other properties set on `VirtualList`, such as `className`, will be reflected on the component's root element.
 

--- a/dist/VirtualList.js
+++ b/dist/VirtualList.js
@@ -9,14 +9,16 @@ var VirtualList = React.createClass({displayName: "VirtualList",
         container: React.PropTypes.object.isRequired,
         tagName: React.PropTypes.string.isRequired,
         scrollDelay: React.PropTypes.number,
-        itemBuffer: React.PropTypes.number
+        itemBuffer: React.PropTypes.number,
+        initialItems: React.PropTypes.array.isRequired
     },
     getDefaultProps: function() {
         return {
             container: typeof window !== 'undefined' ? window : undefined,
             tagName: 'div',
             scrollDelay: 0,
-            itemBuffer: 0
+            itemBuffer: 0,
+            initialItems: []
         };
     },
     getVirtualState: function(props) {
@@ -57,8 +59,13 @@ var VirtualList = React.createClass({displayName: "VirtualList",
         
         return state;
     },
-    getInitialState: function() {
-        return this.getVirtualState(this.props);
+    getInitialState: function () {
+        var items = this.props.initialItems;
+        return {
+            items: items,
+            bufferStart: 0,
+            height: items.length * this.props.itemHeight
+        };
     },
     shouldComponentUpdate: function(nextProps, nextState) {
         if (this.state.bufferStart !== nextState.bufferStart) return true;

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -9,14 +9,16 @@ var VirtualList = React.createClass({
         container: React.PropTypes.object.isRequired,
         tagName: React.PropTypes.string.isRequired,
         scrollDelay: React.PropTypes.number,
-        itemBuffer: React.PropTypes.number
+        itemBuffer: React.PropTypes.number,
+        initialItems: React.PropTypes.array.isRequired
     },
     getDefaultProps: function() {
         return {
             container: typeof window !== 'undefined' ? window : undefined,
             tagName: 'div',
             scrollDelay: 0,
-            itemBuffer: 0
+            itemBuffer: 0,
+            initialItems: []
         };
     },
     getVirtualState: function(props) {
@@ -57,8 +59,13 @@ var VirtualList = React.createClass({
         
         return state;
     },
-    getInitialState: function() {
-        return this.getVirtualState(this.props);
+    getInitialState: function () {
+        var items = this.props.initialItems;
+        return {
+            items: items,
+            bufferStart: 0,
+            height: items.length * this.props.itemHeight
+        };
     },
     shouldComponentUpdate: function(nextProps, nextState) {
         if (this.state.bufferStart !== nextState.bufferStart) return true;


### PR DESCRIPTION
This feature satisfies https://github.com/developerdizzle/react-virtual-list/issues/13 by allowing an `initialItems` prop to be passed into VirtualList which defaults to an empty array. Different things can be done with this:

- Render a subset of the items
```javascript
<VirtualList items={ items } initialItems={ items.slice(0,10) } .../>
```

This allows you to prevent the flash of missing content for the general case, and the size of the slice can be adjusted to the application, how expensive the items are to render, and if the device is known or can be determined. You get server side rendering for free.

- Render a new set of items (such as placeholder items)
```javascript
<VirtualList items={ items } initialItems={ placeholders } .../>
```

If your items are expensive components to render, or rely on external assets like images or XHR data you don't have yet, you can render placeholder items. This prevents the flash of missing content, and is similar to the method used for placeholder content on Facebook's timeline. Server side rendering also works here, though obviously since they are placeholder items, not quite as usefully.