### PR TITLE
Fixed viewTop for Internet Explorer

### DIFF
--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -45,7 +45,7 @@ var VirtualList = React.createClass({
 
         var offsetTop = utils.topDifference(list, container);
 
-        var viewTop = typeof container.scrollY !== 'undefined' ? container.scrollY : container.scrollTop;
+        var viewTop = utils.viewTop(container);
 
         var renderStats = VirtualList.getItems(viewTop, viewHeight, offsetTop, props.itemHeight, items.length, props.itemBuffer);
         

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -20,6 +20,20 @@ function topFromWindow(element) {
     return element.offsetTop + topFromWindow(element.offsetParent);
 }
 
+function viewTop(element) {
+    var viewTop;
+    if (element === window) {
+        viewTop = window.pageYOffset;
+        if (viewTop == null) viewTop = document.documentElement.scrollTop;
+        if (viewTop == null) viewTop = document.body.scrollTop;
+    }
+    else {
+        viewTop = element.scrollY;
+        if (viewTop == null) viewTop = element.scrollTop;
+    }
+    return (viewTop == null) ? 0 : viewTop;
+}
+
 function debounce(func, wait, immediate) {
     if (!wait) return func;
     
@@ -47,5 +61,6 @@ module.exports = {
     areArraysEqual: areArraysEqual,
     topDifference: topDifference,
     topFromWindow: topFromWindow,
+    viewTop: viewTop,
     debounce: debounce
 };


### PR DESCRIPTION
This is a fix for #16

I extracted the `viewTop` conditions into a method in `./utils` and expanded on them to handle `window` and DOM element containers differently. The conditions I added are for cross-browser compatibility extracted from a generalized `window.scrollTop` getter I had.

Providing a test for this specific to Internet Explorer would be kind of a drag, but I tested it manually if that's any help.