### PR TITLE
React 0.14 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/developerdizzle/react-virtual-list",
   "dependencies": {
-    "react": "^0.13.3"
+    "react": "~0.13.x"
   },
   "devDependencies": {
     "gulp": "^3.8.11",

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -41,7 +41,7 @@ var VirtualList = React.createClass({
         // no space to render
         if (viewHeight <= 0) return state;
         
-        var list = this.getDOMNode();
+        var list = React.findDOMNode(this);
 
         var offsetTop = utils.topDifference(list, container);
 


### PR DESCRIPTION
These are the minimal changes required to support React 0.14 without deprecation warnings.

As of the React 0.15, `React.findDOMNode(this)` will [become part of `react-dom`](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#two-packages-react-and-react-dom), so the update will require branching for longer term support of 0.13 (if that's a goal).