### PR TITLE
fixed call to getViewBox and getItems

### DIFF
--- a/dist/VirtualList.js
+++ b/dist/VirtualList.js
@@ -44,7 +44,7 @@ var VirtualList = React.createClass({displayName: "VirtualList",
         
         var listBox = this.listBox(props);
 
-        var renderStats = VirtualList.getItems(viewBox, listBox, props.itemHeight, items.length, props.itemBuffer);
+        var renderStats = VirtualList.getItems(viewBox, listBox, props.itemBuffer, props.itemHeight, items.length);
         
         // no items to render
         if (renderStats.itemsInView.length === 0) return state;
@@ -146,7 +146,7 @@ VirtualList.getBox = function getBox(view, list) {
     };
 };
 
-VirtualList.getItems = function(viewBox, listBox, itemHeight, itemCount, itemBuffer) {
+VirtualList.getItems = function(viewBox, listBox, itemBuffer, itemHeight, itemCount) {
     if (itemCount === 0 || itemHeight === 0) return {
         itemsInView: 0
     };

--- a/dist/VirtualList.js
+++ b/dist/VirtualList.js
@@ -67,7 +67,7 @@ var VirtualList = React.createClass({displayName: "VirtualList",
         return !equal;
     },
     viewBox: function viweBox(nextProps) {
-        return (this.view = this.view || this._getViewBox);
+        return (this.view = this.view || this._getViewBox(nextProps));
     },
     _getViewBox: function _getViewBox(nextProps) {
         return {
@@ -146,7 +146,7 @@ VirtualList.getBox = function getBox(view, list) {
     };
 };
 
-VirtualList.getItems = function(viewBox, listBox, itemBuffer, itemHeight, itemCount) {
+VirtualList.getItems = function(viewBox, listBox, itemHeight, itemCount, itemBuffer) {
     if (itemCount === 0 || itemHeight === 0) return {
         itemsInView: 0
     };

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -44,7 +44,7 @@ var VirtualList = React.createClass({
         
         var listBox = this.listBox(props);
 
-        var renderStats = VirtualList.getItems(viewBox, listBox, props.itemHeight, items.length, props.itemBuffer);
+        var renderStats = VirtualList.getItems(viewBox, listBox, props.itemBuffer, props.itemHeight, items.length);
         
         // no items to render
         if (renderStats.itemsInView.length === 0) return state;
@@ -146,7 +146,7 @@ VirtualList.getBox = function getBox(view, list) {
     };
 };
 
-VirtualList.getItems = function(viewBox, listBox, itemHeight, itemCount, itemBuffer) {
+VirtualList.getItems = function(viewBox, listBox, itemBuffer, itemHeight, itemCount) {
     if (itemCount === 0 || itemHeight === 0) return {
         itemsInView: 0
     };

--- a/src/VirtualList.jsx
+++ b/src/VirtualList.jsx
@@ -67,7 +67,7 @@ var VirtualList = React.createClass({
         return !equal;
     },
     viewBox: function viweBox(nextProps) {
-        return (this.view = this.view || this._getViewBox);
+        return (this.view = this.view || this._getViewBox(nextProps));
     },
     _getViewBox: function _getViewBox(nextProps) {
         return {
@@ -146,7 +146,7 @@ VirtualList.getBox = function getBox(view, list) {
     };
 };
 
-VirtualList.getItems = function(viewBox, listBox, itemBuffer, itemHeight, itemCount) {
+VirtualList.getItems = function(viewBox, listBox, itemHeight, itemCount, itemBuffer) {
     if (itemCount === 0 || itemHeight === 0) return {
         itemsInView: 0
     };


### PR DESCRIPTION
Currently the call to this.viewBox will return a function instead of properly calling _getViewBox and the call to  getItems in getVirtualState does not match order of parameters