### PR TITLE
Fixes multiple lists

### DIFF
--- a/src/VirtualList.js
+++ b/src/VirtualList.js
@@ -49,6 +49,8 @@ const VirtualList = (options, mapVirtualToProps = defaultMapToVirtualProps) => (
     setStateIfNeeded(list, container, items, itemHeight, itemBuffer) {
       // get first and lastItemIndex
       const state = getVisibleItemBounds(list, container, items, itemHeight, itemBuffer);
+      
+      if (state.firstItemIndex > state.lastItemIndex) { return; }
 
       if (state !== undefined && (state.firstItemIndex !== this.state.firstItemIndex || state.lastItemIndex !== this.state.lastItemIndex)) {
         this.setState(state);


### PR DESCRIPTION
I had a list of multiple virtual lists, and when the first list was scrolled over, it continued to update, and resulted in an infinite scrollbar