### PR TITLE
Fix for TypeError from getVisibleItemBounds when items.length is 0

### DIFF
--- a/src/utils/getVisibleItemBounds.js
+++ b/src/utils/getVisibleItemBounds.js
@@ -3,10 +3,12 @@ import getElementTop from './getElementTop';
 
 const getVisibleItemBounds = (list, container, items, itemHeight, itemBuffer) => {
   // early return if we can't calculate
-  if (!container) return undefined;
-  if (!itemHeight) return  undefined;
-  if (!items) return undefined;
-  if (items.length === 0) return undefined;
+  if (!container || !itemHeight || !items || items.length === 0) {
+    return {
+      firstItemIndex: undefined,
+      lastItemIndex: undefined
+    };
+  }
 
   // what the user can see
   const { innerHeight, clientHeight } = container;


### PR DESCRIPTION
[VirtualList.js#54](https://github.com/developerdizzle/react-virtual-list/blob/90fec40d9585f4cc10c8ad22e290362b0b618be7/src/VirtualList.js#L54) compares firstItemIndex vs its previous value. If any of the arguments passed to `getVisibleItemBounds` are undefined (or more critically, if items.length is 0), this check will be a TypeError. This change fixes this.

There should also probably be a test for this.