### PR TITLE
React-Router Back Button EventBinding

### DIFF
--- a/lib/VirtualList.js
+++ b/lib/VirtualList.js
@@ -127,8 +127,10 @@ var VirtualList = function VirtualList(options) {
           this.refreshState();
 
           // add events
-          this.options.container.addEventListener('scroll', this.refreshState);
-          this.options.container.addEventListener('resize', this.refreshState);
+          if (this.options.container) {
+            this.options.container.addEventListener('scroll', this.refreshState);
+            this.options.container.addEventListener('resize', this.refreshState);
+          }
         }
       }, {
         key: 'componentWillUnmount',
@@ -136,8 +138,10 @@ var VirtualList = function VirtualList(options) {
           this._isMounted = false;
 
           // remove events
-          this.options.container.removeEventListener('scroll', this.refreshState);
-          this.options.container.removeEventListener('resize', this.refreshState);
+          if (this.options.container) {
+            this.options.container.removeEventListener('scroll', this.refreshState);
+            this.options.container.removeEventListener('resize', this.refreshState);
+          }
         }
       }, {
         key: 'componentWillReceiveProps',

--- a/src/VirtualList.js
+++ b/src/VirtualList.js
@@ -54,7 +54,7 @@ const VirtualList = (options, mapVirtualToProps = defaultMapToVirtualProps) => (
       const state = getVisibleItemBounds(list, container, items, itemHeight, itemBuffer);
 
       if (state === undefined) { return; }
-      
+
       if (state.firstItemIndex > state.lastItemIndex) { return; }
 
       if (state.firstItemIndex !== this.state.firstItemIndex || state.lastItemIndex !== this.state.lastItemIndex) {
@@ -66,7 +66,7 @@ const VirtualList = (options, mapVirtualToProps = defaultMapToVirtualProps) => (
       if (!this._isMounted) {
         return;
       }
-      
+
       const { itemHeight, items, itemBuffer } = this.props;
 
       this.setStateIfNeeded(this.domNode, this.options.container, items, itemHeight, itemBuffer);
@@ -84,16 +84,20 @@ const VirtualList = (options, mapVirtualToProps = defaultMapToVirtualProps) => (
       this.refreshState();
 
       // add events
-      this.options.container.addEventListener('scroll', this.refreshState);
-      this.options.container.addEventListener('resize', this.refreshState);
+      if (this.options.container) {
+        this.options.container.addEventListener('scroll', this.refreshState);
+        this.options.container.addEventListener('resize', this.refreshState);
+      }
     };
 
     componentWillUnmount() {
       this._isMounted = false;
 
       // remove events
-      this.options.container.removeEventListener('scroll', this.refreshState);
-      this.options.container.removeEventListener('resize', this.refreshState);
+      if (this.options.container) {
+        this.options.container.removeEventListener('scroll', this.refreshState);
+        this.options.container.removeEventListener('resize', this.refreshState);
+      }
     };
 
     // if props change, just assume we have to recalculate


### PR DESCRIPTION
Getting errors for `Cannot read property 'addEventListener' of null` on line 130 of VirtualList.js when pressing my browsers back button after routing to another page via React-Router. Trying to bind the EventListener when not possible.

Internet suggests just a simple safety check. Which helps me out a lot in my case!

https://stackoverflow.com/questions/26107125/cannot-read-property-addeventlistener-of-null