### PR TITLE
fix: error arguments is not defined when using webpack 5

### DIFF
--- a/lib/utils/throttleWithRAF.js
+++ b/lib/utils/throttleWithRAF.js
@@ -3,18 +3,21 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-var _arguments = arguments;
 
 exports.default = function (fn) {
   var running = false;
 
   return function () {
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
     if (running) return;
 
     running = true;
 
     window.requestAnimationFrame(function () {
-      fn.apply(undefined, _arguments);
+      fn.apply(undefined, args);
 
       running = false;
     });

--- a/src/utils/throttleWithRAF.js
+++ b/src/utils/throttleWithRAF.js
@@ -1,13 +1,13 @@
 export default (fn) => {
   let running = false;
 
-  return () => {
+  return (...args) => {
     if (running) return;
 
     running = true;
 
     window.requestAnimationFrame(() => {
-      fn.apply(this, arguments);
+      fn.apply(this, args);
 
       running = false;
     });


### PR DESCRIPTION
**Problem addressed**
`react-virtual-list` package causes error when bundled using webpack 5.
Simply adding `import VirtualList from 'react-virtual-list'` to any file produces the following error:

```
Uncaught ReferenceError: arguments is not defined
    at Object../node_modules/react-virtual-list/lib/utils/throttleWithRAF.js (bundle.js:33553:18)
    at Object.options.factory (bundle.js:70557:31)
    at __webpack_require__ (bundle.js:70007:33)
    at fn (bundle.js:70228:21)
    at Object../node_modules/react-virtual-list/lib/VirtualList.js (bundle.js:33246:24)
    at Object.options.factory (bundle.js:70557:31)
    at __webpack_require__ (bundle.js:70007:33)
    at fn (bundle.js:70228:21)
    at Module../src/App.js (bundle.js:67:76)
    at Module.options.factory (bundle.js:70557:31)
```

That's because webpack 5 uses arrow function to wrap modules but in webpack 4 it was using normal functions.

**Solution**

As seen on [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#no_binding_of_arguments), using rest parameters is a good alternative to using an arguments object.