### PR TITLE
Return early when state is null or undefined

### DIFF
--- a/src/VirtualList.js
+++ b/src/VirtualList.js
@@ -53,7 +53,7 @@ const VirtualList = (options, mapVirtualToProps = defaultMapToVirtualProps) => (
       // get first and lastItemIndex
       const state = getVisibleItemBounds(list, container, items, itemHeight, itemBuffer);
 
-      if (state === undefined) { return; }
+      if (state == null) { return; }
       
       if (state.firstItemIndex > state.lastItemIndex) { return; }
 


### PR DESCRIPTION
The strict equality check for state === undefined in setStateIfNeeded can cause a crash if state is null.